### PR TITLE
Remove io/ioutil

### DIFF
--- a/cli/load.go
+++ b/cli/load.go
@@ -3,7 +3,7 @@ package cli
 
 import (
 	"errors"
-	"io/ioutil"
+	"os"
 
 	"github.com/bitcubix/tego/config"
 	"github.com/manifoldco/promptui"
@@ -20,7 +20,7 @@ func Load() (string, error) {
 	}
 
 	// search for template conig in dir
-	files, err := ioutil.ReadDir(folder_path)
+	files, err := os.ReadDir(folder_path)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
`io/ioutil` has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details